### PR TITLE
Fix for the upstream's change in the version #

### DIFF
--- a/version.go
+++ b/version.go
@@ -11,7 +11,7 @@ var Version struct {
 }
 
 func init() {
-	Version.Major = int(C.NN_VERSION_MAJOR)
-	Version.Minor = int(C.NN_VERSION_MINOR)
-	Version.Patch = int(C.NN_VERSION_PATCH)
+	Version.Major = int(C.NN_VERSION_CURRENT)
+	Version.Minor = int(C.NN_VERSION_REVISION)
+	Version.Patch = int(C.NN_VERSION_AGE)
 }


### PR DESCRIPTION
It looks like the version is still composed of 3 variables in the same order: https://github.com/250bpm/nanomsg/commit/0a5ccfd5c7770c8122947d7e8895ee0e6d928403#L1R40

go-nanomsg.test.exe -test.run=TestVersion -test.v=true
=== RUN TestVersion
--- PASS: TestVersion (0.00 seconds)
PASS

Fixes #4
