### PR TITLE
now get info from pkg-config

### DIFF
--- a/nanomsg.go
+++ b/nanomsg.go
@@ -4,7 +4,7 @@ package nanomsg
 
 // #include <nanomsg/nn.h>
 // #include <stdlib.h>
-// #cgo LDFLAGS: -lnanomsg
+// #cgo pkg-config: libnanomsg
 import "C"
 
 import (


### PR DESCRIPTION
When using homebrew with OS X nanomsg is not located in default lib and include paths so need to use pkg-config to get corret path.

``` bash
$ pkg-config libnanomsg --libs
-L/usr/local/Cellar/nanomsg/0.5-beta/lib -lnanomsg
```
