### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/nanomsg.go
+++ b/nanomsg.go
@@ -112,7 +112,7 @@ func (s *Socket) Bind(address string) (*Endpoint, error) {
 	return &Endpoint{address, eid}, nil
 }
 
-// Add a remote endpoint to the socket.
+// Connect adds a remote endpoint to the socket.
 func (s *Socket) Connect(address string) (*Endpoint, error) {
 	cstr := C.CString(address)
 	defer C.free(unsafe.Pointer(cstr))
@@ -123,7 +123,7 @@ func (s *Socket) Connect(address string) (*Endpoint, error) {
 	return &Endpoint{address, eid}, nil
 }
 
-// Removes an endpoint from the socket. This call will return immediately,
+// Shutdown removes an endpoint from the socket. This call will return immediately,
 // however, the library will try to deliver any outstanding outbound messages
 // to the endpoint for the time specified by the linger socket option.
 func (s *Socket) Shutdown(endpoint *Endpoint) error {


### PR DESCRIPTION
Every exported function in a program should have a doc comment. The first sentence should be a summary that starts with the name being declared.
From [effective go](https://golang.org/doc/effective_go.html#commentary).

I generated this with [CodeLingo](https://codelingo.io) and I'm keen to get some feedback, _but this is automated so feel free to close it and just say "**opt out**" to opt out of future CodeLingo outreach PRs._
